### PR TITLE
Remove bad PEiD Armadillo v1.71 packer signature

### DIFF
--- a/deps/peid/signatures_long.txt
+++ b/deps/peid/signatures_long.txt
@@ -15215,10 +15215,6 @@ ep_only = false
 signature = 30 31 2E 30 31 00 00 04
 ep_only = false
 
-[Armadillo v1.71]
-signature = 55 8B EC 6A FF 68 ?? ?? ?? ?? 68 ?? ?? ?? ?? 64 A1
-ep_only = false
-
 [Armadillo v4.30 - 4.40 -> Silicon Realms Toolworks]
 signature = 55 8B EC 6A FF 68 40 ?? ?? 00 68 80 ?? ?? 00 64 A1 00 00 00 00 50 64 89 25 00 00 00 00 83 EC 58 53 56 57 89 65 E8 FF 15 88 ?? ?? 00 33 D2 8A D4 89 15 30 ?? ?? 00 8B C8 81 E1 FF 00 00 00 89 0D 2C ?? ?? 00 C1 E1 08 03 CA 89 0D 28 ?? ?? 00 C1 E8 10 A3 24 ?? ?? 00 33 F6 56 E8 78 16 00 00 59 85 C0 75 08 6A 1C E8 B0 00 00 00 59 89 75 FC E8 43 13 00 00 FF 15 8C ?? ?? 00 A3 24
 ep_only = false

--- a/deps/peid/signatures_short.txt
+++ b/deps/peid/signatures_short.txt
@@ -813,10 +813,6 @@ ep_only = true
 signature = 55 8B EC 6A FF 68 98 71 40 00 68 48 2D 40 00 64 A1 00 00 00 00 50 64 89 25 00 00 00 00 83 EC 58
 ep_only = true
 
-[Armadillo v1.71]
-signature = 55 8B EC 6A FF 68 ?? ?? ?? ?? 68 ?? ?? ?? ?? 64 A1
-ep_only = true
-
 [Armadillo v1.72 - v1.73]
 signature = 55 8B EC 6A FF 68 E8 C1 ?? ?? 68 F4 86 ?? ?? 64 A1 ?? ?? ?? ?? 50 64 89 25 ?? ?? ?? ?? 83 EC 58
 ep_only = true


### PR DESCRIPTION
The PEiD Armadillo v1.71 signature falsely detects any binaries compiled with MSVC.
This PR removes it from the signatures